### PR TITLE
Allow concurrent connections to get health faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,59 +9,49 @@ module.exports = function (torrent) {
 	var health = {};
 
 	readtorrent(torrent, function(err, torrentInfo) {
-		if(err) {
+		if (err) {
 			defer.reject(err);
-		}
-
-		else {
+		} else {
 			var tracker;
 
-			async.eachSeries(
-				torrentInfo.announce,
-				function(tr, cb) {
-					// Avoid trackers causing timeout
-					if (tr === 'udp://open.demonii.com:80') {
-						return cb();
-					}
-					tracker = new Tracker(tr+'/announce');
+			async.eachLimit(torrentInfo.announce, 10, function(tr, cb) {
+				tracker = new Tracker(tr+'/announce');
+				setTimeout(function() {
+					var resolved = null;
+					// Timeout and continue with other sources
 					setTimeout(function() {
-						var resolved = null;
-						// Timeout and continue with other sources
-						setTimeout(function() {
-							if (!resolved) {
-								tracker.close();
-								cb();
-							}
-						}, 3000);
-
-						tracker.scrape([torrentInfo.infoHash], function(err, msg) {
-							if(err) return cb();
-							if(msg[torrentInfo.infoHash]) {
-								results.push({
-									seeds: msg[torrentInfo.infoHash].seeders, 
-									peers: msg[torrentInfo.infoHash].leechers
-								});
-							}
-							resolved = true;
+						if (!resolved) {
 							tracker.close();
 							cb();
-						});
-					}, 1000);
-				},
-				function(err) {
-					var totalSeeds = 0;
-					var totalPeers = 0;
-					for(var r in results) {
-						totalSeeds += results[r].seeds;
-						totalPeers += results[r].peers;
-					}
-					health.seeds = Math.round(totalSeeds/results.length);
-					health.peers = Math.round(totalPeers/results.length);
-					defer.resolve(health);
+						}
+					}, 3000);
+
+					tracker.scrape([torrentInfo.infoHash], function(err, msg) {
+						if(err) return cb();
+						if(msg[torrentInfo.infoHash]) {
+							results.push({
+								seeds: msg[torrentInfo.infoHash].seeders, 
+								peers: msg[torrentInfo.infoHash].leechers
+							});
+						}
+						resolved = true;
+						tracker.close();
+						cb();
+					});
+				}, 1000);
+			}, function(err) {
+				var totalSeeds = 0;
+				var totalPeers = 0;
+				for(var r in results) {
+					totalSeeds += results[r].seeds;
+					totalPeers += results[r].peers;
 				}
-			)
+				health.seeds = Math.round(totalSeeds/results.length);
+				health.peers = Math.round(totalPeers/results.length);
+				defer.resolve(health);
+			});
 		}
 	});
 
 	return defer.promise;
-}
+};


### PR DESCRIPTION
Use eachLimit instead of eachSeries, with a reasonably low limit of concurrency (10). This runs health checks in parallel instead of sequentially, making health check much faster.
